### PR TITLE
chore: fix linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -68,7 +68,7 @@ linters-settings:
       - prefix(github.com/cosmos) # cosmos org
       - prefix(cosmossdk.io) # new modules
       - prefix(github.com/cosmos/cosmos-sdk) # cosmos sdk
-      - prefix(github.com/govgen/govgen) # govgen
+      - prefix(github.com/atomone-hub/govgen) # govgen
   dogsled:
     max-blank-identifiers: 3
   maligned:

--- a/ante/ante.go
+++ b/ante/ante.go
@@ -1,15 +1,15 @@
 package ante
 
 import (
-	"github.com/atomone-hub/govgen/v1/types/errors"
-	govkeeper "github.com/atomone-hub/govgen/v1/x/gov/keeper"
-
 	errorsmod "cosmossdk.io/errors"
 
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/auth/ante"
 	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
+
+	"github.com/atomone-hub/govgen/v1/types/errors"
+	govkeeper "github.com/atomone-hub/govgen/v1/x/gov/keeper"
 )
 
 // HandlerOptions extend the SDK's AnteHandler options by requiring the IBC

--- a/ante/fee_test.go
+++ b/ante/fee_test.go
@@ -4,9 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/atomone-hub/govgen/v1/ante"
-	govgenapp "github.com/atomone-hub/govgen/v1/app"
-	govgenhelpers "github.com/atomone-hub/govgen/v1/app/helpers"
 	"github.com/stretchr/testify/suite"
 	tmrand "github.com/tendermint/tendermint/libs/rand"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
@@ -19,6 +16,10 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/tx/signing"
 	xauthsigning "github.com/cosmos/cosmos-sdk/x/auth/signing"
+
+	"github.com/atomone-hub/govgen/v1/ante"
+	govgenapp "github.com/atomone-hub/govgen/v1/app"
+	govgenhelpers "github.com/atomone-hub/govgen/v1/app/helpers"
 )
 
 type FeeIntegrationTestSuite struct {

--- a/ante/gov_ante.go
+++ b/ante/gov_ante.go
@@ -1,15 +1,15 @@
 package ante
 
 import (
-	"github.com/atomone-hub/govgen/v1/types/errors"
-	govkeeper "github.com/atomone-hub/govgen/v1/x/gov/keeper"
-	govtypes "github.com/atomone-hub/govgen/v1/x/gov/types"
-
 	errorsmod "cosmossdk.io/errors"
 
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/authz"
+
+	"github.com/atomone-hub/govgen/v1/types/errors"
+	govkeeper "github.com/atomone-hub/govgen/v1/x/gov/keeper"
+	govtypes "github.com/atomone-hub/govgen/v1/x/gov/types"
 )
 
 // initial deposit must be greater than or equal to 1% of the minimum deposit

--- a/ante/gov_ante_test.go
+++ b/ante/gov_ante_test.go
@@ -4,10 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/atomone-hub/govgen/v1/ante"
-	govgenapp "github.com/atomone-hub/govgen/v1/app"
-	govgenhelpers "github.com/atomone-hub/govgen/v1/app/helpers"
-	govtypes "github.com/atomone-hub/govgen/v1/x/gov/types"
 	"github.com/stretchr/testify/suite"
 	tmrand "github.com/tendermint/tendermint/libs/rand"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
@@ -15,6 +11,11 @@ import (
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/testutil/testdata"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/atomone-hub/govgen/v1/ante"
+	govgenapp "github.com/atomone-hub/govgen/v1/app"
+	govgenhelpers "github.com/atomone-hub/govgen/v1/app/helpers"
+	govtypes "github.com/atomone-hub/govgen/v1/x/gov/types"
 )
 
 var (

--- a/app/app.go
+++ b/app/app.go
@@ -7,11 +7,6 @@ import (
 	"os"
 	"path/filepath"
 
-	govgenante "github.com/atomone-hub/govgen/v1/ante"
-	"github.com/atomone-hub/govgen/v1/app/keepers"
-	govgenappparams "github.com/atomone-hub/govgen/v1/app/params"
-	"github.com/atomone-hub/govgen/v1/app/upgrades"
-	govtypes "github.com/atomone-hub/govgen/v1/x/gov/types"
 	"github.com/gorilla/mux"
 	"github.com/rakyll/statik/fs"
 	"github.com/spf13/cast"
@@ -45,6 +40,12 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/crisis"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
+
+	govgenante "github.com/atomone-hub/govgen/v1/ante"
+	"github.com/atomone-hub/govgen/v1/app/keepers"
+	govgenappparams "github.com/atomone-hub/govgen/v1/app/params"
+	"github.com/atomone-hub/govgen/v1/app/upgrades"
+	govtypes "github.com/atomone-hub/govgen/v1/x/gov/types"
 )
 
 var (

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -3,14 +3,15 @@ package govgen_test
 import (
 	"testing"
 
-	govgen "github.com/atomone-hub/govgen/v1/app"
-	govgenhelpers "github.com/atomone-hub/govgen/v1/app/helpers"
-	govtypes "github.com/atomone-hub/govgen/v1/x/gov/types"
 	"github.com/stretchr/testify/require"
 	"github.com/tendermint/tendermint/libs/log"
 	db "github.com/tendermint/tm-db"
 
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+
+	govgen "github.com/atomone-hub/govgen/v1/app"
+	govgenhelpers "github.com/atomone-hub/govgen/v1/app/helpers"
+	govtypes "github.com/atomone-hub/govgen/v1/x/gov/types"
 )
 
 type EmptyAppOptions struct{}

--- a/app/encoding.go
+++ b/app/encoding.go
@@ -1,9 +1,9 @@
 package govgen
 
 import (
-	"github.com/atomone-hub/govgen/v1/app/params"
-
 	"github.com/cosmos/cosmos-sdk/std"
+
+	"github.com/atomone-hub/govgen/v1/app/params"
 )
 
 // MakeTestEncodingConfig creates an EncodingConfig for testing. This function

--- a/app/helpers/test_helpers.go
+++ b/app/helpers/test_helpers.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 	"time"
 
-	govgenapp "github.com/atomone-hub/govgen/v1/app"
 	"github.com/stretchr/testify/require"
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/crypto"
@@ -33,6 +32,8 @@ import (
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	minttypes "github.com/cosmos/cosmos-sdk/x/mint/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+
+	govgenapp "github.com/atomone-hub/govgen/v1/app"
 )
 
 // SimAppChainID hardcoded chainID for simulation

--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -1,8 +1,6 @@
 package keepers
 
 import (
-	govkeeper "github.com/atomone-hub/govgen/v1/x/gov/keeper"
-	govtypes "github.com/atomone-hub/govgen/v1/x/gov/types"
 	tmos "github.com/tendermint/tendermint/libs/os"
 
 	// unnamed import of statik for swagger UI support
@@ -42,6 +40,9 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/upgrade"
 	upgradekeeper "github.com/cosmos/cosmos-sdk/x/upgrade/keeper"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
+
+	govkeeper "github.com/atomone-hub/govgen/v1/x/gov/keeper"
+	govtypes "github.com/atomone-hub/govgen/v1/x/gov/types"
 )
 
 type AppKeepers struct {

--- a/app/keepers/keys.go
+++ b/app/keepers/keys.go
@@ -1,8 +1,6 @@
 package keepers
 
 import (
-	govtypes "github.com/atomone-hub/govgen/v1/x/gov/types"
-
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
@@ -17,6 +15,8 @@ import (
 	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
+
+	govtypes "github.com/atomone-hub/govgen/v1/x/gov/types"
 )
 
 func (appKeepers *AppKeepers) GenerateKeys() {

--- a/app/modules.go
+++ b/app/modules.go
@@ -1,10 +1,6 @@
 package govgen
 
 import (
-	govgenappparams "github.com/atomone-hub/govgen/v1/app/params"
-	"github.com/atomone-hub/govgen/v1/x/gov"
-	govtypes "github.com/atomone-hub/govgen/v1/x/gov/types"
-
 	"github.com/cosmos/cosmos-sdk/types/module"
 	"github.com/cosmos/cosmos-sdk/x/auth"
 	authsims "github.com/cosmos/cosmos-sdk/x/auth/simulation"
@@ -40,6 +36,10 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/upgrade"
 	upgradeclient "github.com/cosmos/cosmos-sdk/x/upgrade/client"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
+
+	govgenappparams "github.com/atomone-hub/govgen/v1/app/params"
+	"github.com/atomone-hub/govgen/v1/x/gov"
+	govtypes "github.com/atomone-hub/govgen/v1/x/gov/types"
 )
 
 var maccPerms = map[string][]string{

--- a/app/sim/sim_state.go
+++ b/app/sim/sim_state.go
@@ -8,8 +8,6 @@ import (
 	"os"
 	"time"
 
-	govgen "github.com/atomone-hub/govgen/v1/app"
-	appparams "github.com/atomone-hub/govgen/v1/app/params"
 	tmjson "github.com/tendermint/tendermint/libs/json"
 	tmtypes "github.com/tendermint/tendermint/types"
 
@@ -21,6 +19,9 @@ import (
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+
+	govgen "github.com/atomone-hub/govgen/v1/app"
+	appparams "github.com/atomone-hub/govgen/v1/app/params"
 )
 
 // AppStateFn returns the initial application state using a genesis or the simulation parameters.

--- a/app/sim/sim_utils.go
+++ b/app/sim/sim_utils.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 
-	govgen "github.com/atomone-hub/govgen/v1/app"
 	"github.com/tendermint/tendermint/libs/log"
 	dbm "github.com/tendermint/tm-db"
 
@@ -15,6 +14,8 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/kv"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
+
+	govgen "github.com/atomone-hub/govgen/v1/app"
 )
 
 // SetupSimulation creates the config, db (levelDB), temporary directory and logger for

--- a/app/sim_test.go
+++ b/app/sim_test.go
@@ -7,10 +7,6 @@ import (
 	"os"
 	"testing"
 
-	govgen "github.com/atomone-hub/govgen/v1/app"
-	"github.com/atomone-hub/govgen/v1/app/helpers"
-	"github.com/atomone-hub/govgen/v1/app/params"
-	"github.com/atomone-hub/govgen/v1/app/sim"
 	"github.com/stretchr/testify/require"
 	"github.com/tendermint/tendermint/libs/log"
 	dbm "github.com/tendermint/tm-db"
@@ -20,6 +16,11 @@ import (
 	"github.com/cosmos/cosmos-sdk/store"
 	simulation2 "github.com/cosmos/cosmos-sdk/types/simulation"
 	"github.com/cosmos/cosmos-sdk/x/simulation"
+
+	govgen "github.com/atomone-hub/govgen/v1/app"
+	"github.com/atomone-hub/govgen/v1/app/helpers"
+	"github.com/atomone-hub/govgen/v1/app/params"
+	"github.com/atomone-hub/govgen/v1/app/sim"
 )
 
 func init() {

--- a/app/upgrades/types.go
+++ b/app/upgrades/types.go
@@ -1,12 +1,12 @@
 package upgrades
 
 import (
-	"github.com/atomone-hub/govgen/v1/app/keepers"
-
 	store "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
+
+	"github.com/atomone-hub/govgen/v1/app/keepers"
 )
 
 // Upgrade defines a struct containing necessary fields that a SoftwareUpgradeProposal

--- a/cmd/govgend/cmd/bech32_convert.go
+++ b/cmd/govgend/cmd/bech32_convert.go
@@ -3,8 +3,9 @@ package cmd
 import (
 	"fmt"
 
-	addressutil "github.com/atomone-hub/govgen/v1/pkg/address"
 	"github.com/spf13/cobra"
+
+	addressutil "github.com/atomone-hub/govgen/v1/pkg/address"
 )
 
 var flagBech32Prefix = "prefix"

--- a/cmd/govgend/cmd/root.go
+++ b/cmd/govgend/cmd/root.go
@@ -6,8 +6,6 @@ import (
 	"os"
 	"path/filepath"
 
-	govgen "github.com/atomone-hub/govgen/v1/app"
-	"github.com/atomone-hub/govgen/v1/app/params"
 	"github.com/spf13/cast"
 	"github.com/spf13/cobra"
 	tmcli "github.com/tendermint/tendermint/libs/cli"
@@ -32,6 +30,9 @@ import (
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	"github.com/cosmos/cosmos-sdk/x/crisis"
 	genutilcli "github.com/cosmos/cosmos-sdk/x/genutil/client/cli"
+
+	govgen "github.com/atomone-hub/govgen/v1/app"
+	"github.com/atomone-hub/govgen/v1/app/params"
 )
 
 // NewRootCmd creates a new root command for simd. It is called once in the

--- a/cmd/govgend/cmd/root_test.go
+++ b/cmd/govgend/cmd/root_test.go
@@ -3,11 +3,12 @@ package cmd_test
 import (
 	"testing"
 
-	app "github.com/atomone-hub/govgen/v1/app"
-	"github.com/atomone-hub/govgen/v1/cmd/govgend/cmd"
 	"github.com/stretchr/testify/require"
 
 	svrcmd "github.com/cosmos/cosmos-sdk/server/cmd"
+
+	app "github.com/atomone-hub/govgen/v1/app"
+	"github.com/atomone-hub/govgen/v1/cmd/govgend/cmd"
 )
 
 func TestRootCmdConfig(t *testing.T) {

--- a/cmd/govgend/main.go
+++ b/cmd/govgend/main.go
@@ -3,11 +3,11 @@ package main
 import (
 	"os"
 
-	app "github.com/atomone-hub/govgen/v1/app"
-	"github.com/atomone-hub/govgen/v1/cmd/govgend/cmd"
-
 	"github.com/cosmos/cosmos-sdk/server"
 	svrcmd "github.com/cosmos/cosmos-sdk/server/cmd"
+
+	app "github.com/atomone-hub/govgen/v1/app"
+	"github.com/atomone-hub/govgen/v1/cmd/govgend/cmd"
 )
 
 func main() {

--- a/x/gov/abci.go
+++ b/x/gov/abci.go
@@ -4,11 +4,11 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/atomone-hub/govgen/v1/x/gov/keeper"
-	"github.com/atomone-hub/govgen/v1/x/gov/types"
-
 	"github.com/cosmos/cosmos-sdk/telemetry"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/atomone-hub/govgen/v1/x/gov/keeper"
+	"github.com/atomone-hub/govgen/v1/x/gov/types"
 )
 
 // EndBlocker called every block, process inflation, update validator set.

--- a/x/gov/abci_test.go
+++ b/x/gov/abci_test.go
@@ -4,9 +4,6 @@ import (
 	"testing"
 	"time"
 
-	govgenhelpers "github.com/atomone-hub/govgen/v1/app/helpers"
-	"github.com/atomone-hub/govgen/v1/x/gov"
-	"github.com/atomone-hub/govgen/v1/x/gov/types"
 	"github.com/golang/protobuf/proto" //nolint:staticcheck
 	"github.com/stretchr/testify/require"
 	abci "github.com/tendermint/tendermint/abci/types"
@@ -14,6 +11,10 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/staking"
+
+	govgenhelpers "github.com/atomone-hub/govgen/v1/app/helpers"
+	"github.com/atomone-hub/govgen/v1/x/gov"
+	"github.com/atomone-hub/govgen/v1/x/gov/types"
 )
 
 func TestTickExpiredDepositPeriod(t *testing.T) {

--- a/x/gov/client/cli/parse.go
+++ b/x/gov/client/cli/parse.go
@@ -5,8 +5,9 @@ import (
 	"fmt"
 	"os"
 
-	govutils "github.com/atomone-hub/govgen/v1/x/gov/client/utils"
 	"github.com/spf13/pflag"
+
+	govutils "github.com/atomone-hub/govgen/v1/x/gov/client/utils"
 )
 
 func parseSubmitProposalFlags(fs *pflag.FlagSet) (*proposal, error) {

--- a/x/gov/client/cli/query.go
+++ b/x/gov/client/cli/query.go
@@ -5,14 +5,15 @@ import (
 	"strconv"
 	"strings"
 
-	gcutils "github.com/atomone-hub/govgen/v1/x/gov/client/utils"
-	"github.com/atomone-hub/govgen/v1/x/gov/types"
 	"github.com/spf13/cobra"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/version"
+
+	gcutils "github.com/atomone-hub/govgen/v1/x/gov/client/utils"
+	"github.com/atomone-hub/govgen/v1/x/gov/types"
 )
 
 // GetQueryCmd returns the cli query commands for this module

--- a/x/gov/client/cli/tx.go
+++ b/x/gov/client/cli/tx.go
@@ -5,8 +5,6 @@ import (
 	"strconv"
 	"strings"
 
-	govutils "github.com/atomone-hub/govgen/v1/x/gov/client/utils"
-	"github.com/atomone-hub/govgen/v1/x/gov/types"
 	"github.com/spf13/cobra"
 
 	"github.com/cosmos/cosmos-sdk/client"
@@ -14,6 +12,9 @@ import (
 	"github.com/cosmos/cosmos-sdk/client/tx"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/version"
+
+	govutils "github.com/atomone-hub/govgen/v1/x/gov/client/utils"
+	"github.com/atomone-hub/govgen/v1/x/gov/types"
 )
 
 // Proposal flags

--- a/x/gov/client/proposal_handler.go
+++ b/x/gov/client/proposal_handler.go
@@ -1,11 +1,12 @@
 package client
 
 import (
-	"github.com/atomone-hub/govgen/v1/x/gov/client/rest"
 	"github.com/spf13/cobra"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	legacyclient "github.com/cosmos/cosmos-sdk/x/gov/client"
+
+	"github.com/atomone-hub/govgen/v1/x/gov/client/rest"
 )
 
 // function to create the rest handler

--- a/x/gov/client/rest/query.go
+++ b/x/gov/client/rest/query.go
@@ -5,13 +5,14 @@ import (
 	"fmt"
 	"net/http"
 
-	gcutils "github.com/atomone-hub/govgen/v1/x/gov/client/utils"
-	"github.com/atomone-hub/govgen/v1/x/gov/types"
 	"github.com/gorilla/mux"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/rest"
+
+	gcutils "github.com/atomone-hub/govgen/v1/x/gov/client/utils"
+	"github.com/atomone-hub/govgen/v1/x/gov/types"
 )
 
 func registerQueryRoutes(clientCtx client.Context, r *mux.Router) {

--- a/x/gov/client/rest/tx.go
+++ b/x/gov/client/rest/tx.go
@@ -4,13 +4,14 @@ import (
 	"fmt"
 	"net/http"
 
-	gcutils "github.com/atomone-hub/govgen/v1/x/gov/client/utils"
-	"github.com/atomone-hub/govgen/v1/x/gov/types"
 	"github.com/gorilla/mux"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/tx"
 	"github.com/cosmos/cosmos-sdk/types/rest"
+
+	gcutils "github.com/atomone-hub/govgen/v1/x/gov/client/utils"
+	"github.com/atomone-hub/govgen/v1/x/gov/types"
 )
 
 func registerTxHandlers(clientCtx client.Context, r *mux.Router, phs []ProposalRESTHandler) {

--- a/x/gov/client/testutil/deposits.go
+++ b/x/gov/client/testutil/deposits.go
@@ -4,14 +4,15 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/atomone-hub/govgen/v1/x/gov/client/cli"
-	"github.com/atomone-hub/govgen/v1/x/gov/types"
 	"github.com/stretchr/testify/suite"
 	tmcli "github.com/tendermint/tendermint/libs/cli"
 
 	clitestutil "github.com/cosmos/cosmos-sdk/testutil/cli"
 	"github.com/cosmos/cosmos-sdk/testutil/network"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/atomone-hub/govgen/v1/x/gov/client/cli"
+	"github.com/atomone-hub/govgen/v1/x/gov/types"
 )
 
 type DepositTestSuite struct {

--- a/x/gov/client/testutil/helpers.go
+++ b/x/gov/client/testutil/helpers.go
@@ -3,13 +3,13 @@ package testutil
 import (
 	"fmt"
 
-	govcli "github.com/atomone-hub/govgen/v1/x/gov/client/cli"
-
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/testutil"
 	clitestutil "github.com/cosmos/cosmos-sdk/testutil/cli"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	govcli "github.com/atomone-hub/govgen/v1/x/gov/client/cli"
 )
 
 var commonArgs = []string{

--- a/x/gov/client/testutil/suite.go
+++ b/x/gov/client/testutil/suite.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/atomone-hub/govgen/v1/x/gov/client/cli"
-	"github.com/atomone-hub/govgen/v1/x/gov/types"
 	"github.com/gogo/protobuf/proto"
 	"github.com/stretchr/testify/suite"
 	tmcli "github.com/tendermint/tendermint/libs/cli"
@@ -15,6 +13,9 @@ import (
 	clitestutil "github.com/cosmos/cosmos-sdk/testutil/cli"
 	"github.com/cosmos/cosmos-sdk/testutil/network"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/atomone-hub/govgen/v1/x/gov/client/cli"
+	"github.com/atomone-hub/govgen/v1/x/gov/types"
 )
 
 type IntegrationTestSuite struct {

--- a/x/gov/client/utils/query.go
+++ b/x/gov/client/utils/query.go
@@ -3,12 +3,12 @@ package utils
 import (
 	"fmt"
 
-	"github.com/atomone-hub/govgen/v1/x/gov/types"
-
 	"github.com/cosmos/cosmos-sdk/client"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	authtx "github.com/cosmos/cosmos-sdk/x/auth/tx"
+
+	"github.com/atomone-hub/govgen/v1/x/gov/types"
 )
 
 const (

--- a/x/gov/client/utils/query_test.go
+++ b/x/gov/client/utils/query_test.go
@@ -5,9 +5,6 @@ import (
 	"regexp"
 	"testing"
 
-	govgenapp "github.com/atomone-hub/govgen/v1/app"
-	"github.com/atomone-hub/govgen/v1/x/gov/client/utils"
-	"github.com/atomone-hub/govgen/v1/x/gov/types"
 	"github.com/stretchr/testify/require"
 	"github.com/tendermint/tendermint/rpc/client/mock"
 	ctypes "github.com/tendermint/tendermint/rpc/core/types"
@@ -16,6 +13,10 @@ import (
 	"github.com/cosmos/cosmos-sdk/client"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/auth/legacy/legacytx"
+
+	govgenapp "github.com/atomone-hub/govgen/v1/app"
+	"github.com/atomone-hub/govgen/v1/x/gov/client/utils"
+	"github.com/atomone-hub/govgen/v1/x/gov/types"
 )
 
 type TxSearchMock struct {

--- a/x/gov/client/utils/utils_test.go
+++ b/x/gov/client/utils/utils_test.go
@@ -3,8 +3,9 @@ package utils_test
 import (
 	"testing"
 
-	"github.com/atomone-hub/govgen/v1/x/gov/client/utils"
 	"github.com/stretchr/testify/require"
+
+	"github.com/atomone-hub/govgen/v1/x/gov/client/utils"
 )
 
 func TestNormalizeWeightedVoteOptions(t *testing.T) {

--- a/x/gov/common_test.go
+++ b/x/gov/common_test.go
@@ -6,13 +6,14 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/atomone-hub/govgen/v1/x/gov/types"
 	"github.com/stretchr/testify/require"
 
 	"github.com/cosmos/cosmos-sdk/crypto/keys/ed25519"
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+
+	"github.com/atomone-hub/govgen/v1/x/gov/types"
 )
 
 var (

--- a/x/gov/genesis.go
+++ b/x/gov/genesis.go
@@ -3,10 +3,10 @@ package gov
 import (
 	"fmt"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	"github.com/atomone-hub/govgen/v1/x/gov/keeper"
 	"github.com/atomone-hub/govgen/v1/x/gov/types"
-
-	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 // InitGenesis - store genesis parameters

--- a/x/gov/genesis_test.go
+++ b/x/gov/genesis_test.go
@@ -4,10 +4,6 @@ import (
 	"encoding/json"
 	"testing"
 
-	govgenapp "github.com/atomone-hub/govgen/v1/app"
-	govgenhelpers "github.com/atomone-hub/govgen/v1/app/helpers"
-	"github.com/atomone-hub/govgen/v1/x/gov"
-	"github.com/atomone-hub/govgen/v1/x/gov/types"
 	"github.com/stretchr/testify/require"
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/libs/log"
@@ -18,6 +14,11 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/auth"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+
+	govgenapp "github.com/atomone-hub/govgen/v1/app"
+	govgenhelpers "github.com/atomone-hub/govgen/v1/app/helpers"
+	"github.com/atomone-hub/govgen/v1/x/gov"
+	"github.com/atomone-hub/govgen/v1/x/gov/types"
 )
 
 func TestImportExportQueues(t *testing.T) {

--- a/x/gov/handler.go
+++ b/x/gov/handler.go
@@ -1,11 +1,11 @@
 package gov
 
 import (
-	"github.com/atomone-hub/govgen/v1/x/gov/keeper"
-	"github.com/atomone-hub/govgen/v1/x/gov/types"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+
+	"github.com/atomone-hub/govgen/v1/x/gov/keeper"
+	"github.com/atomone-hub/govgen/v1/x/gov/types"
 )
 
 // NewHandler creates an sdk.Handler for all the gov type messages

--- a/x/gov/handler_test.go
+++ b/x/gov/handler_test.go
@@ -4,13 +4,14 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/atomone-hub/govgen/v1/x/gov"
-	"github.com/atomone-hub/govgen/v1/x/gov/keeper"
 	"github.com/stretchr/testify/require"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 
 	"github.com/cosmos/cosmos-sdk/testutil/testdata"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/atomone-hub/govgen/v1/x/gov"
+	"github.com/atomone-hub/govgen/v1/x/gov/keeper"
 )
 
 func TestInvalidMsg(t *testing.T) {

--- a/x/gov/keeper/common_test.go
+++ b/x/gov/keeper/common_test.go
@@ -3,20 +3,21 @@ package keeper_test
 import (
 	"testing"
 
-	govgenapp "github.com/atomone-hub/govgen/v1/app"
-	govgenhelpers "github.com/atomone-hub/govgen/v1/app/helpers"
-	"github.com/atomone-hub/govgen/v1/x/gov/types"
 	"github.com/stretchr/testify/require"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/staking"
 	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+
+	govgenapp "github.com/atomone-hub/govgen/v1/app"
+	govgenhelpers "github.com/atomone-hub/govgen/v1/app/helpers"
+	"github.com/atomone-hub/govgen/v1/x/gov/types"
 )
 
 var TestProposal = types.NewTextProposal("Test", "description")
 
-func createValidators(t *testing.T, ctx sdk.Context, app *govgenapp.GovGenApp, powers []int64) ([]sdk.AccAddress, []sdk.ValAddress) { //nolint: thelper
+func createValidators(t *testing.T, ctx sdk.Context, app *govgenapp.GovGenApp, powers []int64) ([]sdk.AccAddress, []sdk.ValAddress) { //nolint: thelper,unparam
 	addrs := govgenhelpers.AddTestAddrsIncremental(app, ctx, 5, sdk.NewInt(30000000))
 	valAddrs := govgenhelpers.ConvertAddrsToValAddrs(addrs)
 	pks := govgenhelpers.CreateTestPubKeys(5)

--- a/x/gov/keeper/deposit.go
+++ b/x/gov/keeper/deposit.go
@@ -3,10 +3,10 @@ package keeper
 import (
 	"fmt"
 
-	"github.com/atomone-hub/govgen/v1/x/gov/types"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+
+	"github.com/atomone-hub/govgen/v1/x/gov/types"
 )
 
 // GetDeposit gets the deposit of a specific depositor on a specific proposal

--- a/x/gov/keeper/deposit_test.go
+++ b/x/gov/keeper/deposit_test.go
@@ -4,11 +4,12 @@ import (
 	"testing"
 	"time"
 
-	govgenhelpers "github.com/atomone-hub/govgen/v1/app/helpers"
 	"github.com/stretchr/testify/require"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	govgenhelpers "github.com/atomone-hub/govgen/v1/app/helpers"
 )
 
 func TestDeposits(t *testing.T) {

--- a/x/gov/keeper/grpc_query.go
+++ b/x/gov/keeper/grpc_query.go
@@ -3,13 +3,14 @@ package keeper
 import (
 	"context"
 
-	"github.com/atomone-hub/govgen/v1/x/gov/types"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
 	"github.com/cosmos/cosmos-sdk/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/query"
+
+	"github.com/atomone-hub/govgen/v1/x/gov/types"
 )
 
 var _ types.QueryServer = Keeper{}

--- a/x/gov/keeper/grpc_query_test.go
+++ b/x/gov/keeper/grpc_query_test.go
@@ -5,12 +5,12 @@ import (
 	"fmt"
 	"strconv"
 
-	govgenhelpers "github.com/atomone-hub/govgen/v1/app/helpers"
-	"github.com/atomone-hub/govgen/v1/x/gov/types"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/query"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+
+	govgenhelpers "github.com/atomone-hub/govgen/v1/app/helpers"
+	"github.com/atomone-hub/govgen/v1/x/gov/types"
 )
 
 func (suite *KeeperTestSuite) TestGRPCQueryProposal() {

--- a/x/gov/keeper/hooks.go
+++ b/x/gov/keeper/hooks.go
@@ -1,9 +1,9 @@
 package keeper
 
 import (
-	"github.com/atomone-hub/govgen/v1/x/gov/types"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/atomone-hub/govgen/v1/x/gov/types"
 )
 
 // Implements GovHooks interface

--- a/x/gov/keeper/hooks_test.go
+++ b/x/gov/keeper/hooks_test.go
@@ -4,14 +4,15 @@ import (
 	"testing"
 	"time"
 
-	govgenhelpers "github.com/atomone-hub/govgen/v1/app/helpers"
-	"github.com/atomone-hub/govgen/v1/x/gov"
-	"github.com/atomone-hub/govgen/v1/x/gov/keeper"
-	"github.com/atomone-hub/govgen/v1/x/gov/types"
 	"github.com/stretchr/testify/require"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	govgenhelpers "github.com/atomone-hub/govgen/v1/app/helpers"
+	"github.com/atomone-hub/govgen/v1/x/gov"
+	"github.com/atomone-hub/govgen/v1/x/gov/keeper"
+	"github.com/atomone-hub/govgen/v1/x/gov/types"
 )
 
 var _ types.GovHooks = &MockGovHooksReceiver{}

--- a/x/gov/keeper/invariants.go
+++ b/x/gov/keeper/invariants.go
@@ -5,9 +5,9 @@ package keeper
 import (
 	"fmt"
 
-	"github.com/atomone-hub/govgen/v1/x/gov/types"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/atomone-hub/govgen/v1/x/gov/types"
 )
 
 // RegisterInvariants registers all governance invariants

--- a/x/gov/keeper/keeper.go
+++ b/x/gov/keeper/keeper.go
@@ -4,12 +4,13 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/atomone-hub/govgen/v1/x/gov/types"
 	"github.com/tendermint/tendermint/libs/log"
 
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+
+	"github.com/atomone-hub/govgen/v1/x/gov/types"
 )
 
 // Keeper defines the governance module Keeper

--- a/x/gov/keeper/keeper_test.go
+++ b/x/gov/keeper/keeper_test.go
@@ -3,15 +3,16 @@ package keeper_test
 import (
 	"testing"
 
-	govgenapp "github.com/atomone-hub/govgen/v1/app"
-	govgenhelpers "github.com/atomone-hub/govgen/v1/app/helpers"
-	"github.com/atomone-hub/govgen/v1/x/gov/types"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	govgenapp "github.com/atomone-hub/govgen/v1/app"
+	govgenhelpers "github.com/atomone-hub/govgen/v1/app/helpers"
+	"github.com/atomone-hub/govgen/v1/x/gov/types"
 )
 
 type KeeperTestSuite struct {

--- a/x/gov/keeper/msg_server.go
+++ b/x/gov/keeper/msg_server.go
@@ -6,10 +6,11 @@ import (
 	"strconv"
 
 	"github.com/armon/go-metrics"
-	"github.com/atomone-hub/govgen/v1/x/gov/types"
 
 	"github.com/cosmos/cosmos-sdk/telemetry"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/atomone-hub/govgen/v1/x/gov/types"
 )
 
 type msgServer struct {

--- a/x/gov/keeper/params.go
+++ b/x/gov/keeper/params.go
@@ -1,9 +1,9 @@
 package keeper
 
 import (
-	"github.com/atomone-hub/govgen/v1/x/gov/types"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/atomone-hub/govgen/v1/x/gov/types"
 )
 
 // GetDepositParams returns the current DepositParams from the global param store

--- a/x/gov/keeper/proposal.go
+++ b/x/gov/keeper/proposal.go
@@ -3,11 +3,11 @@ package keeper
 import (
 	"fmt"
 
-	"github.com/atomone-hub/govgen/v1/x/gov/types"
-
 	"github.com/cosmos/cosmos-sdk/client"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+
+	"github.com/atomone-hub/govgen/v1/x/gov/types"
 )
 
 // SubmitProposal create new proposal given a content

--- a/x/gov/keeper/proposal_test.go
+++ b/x/gov/keeper/proposal_test.go
@@ -6,9 +6,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/atomone-hub/govgen/v1/x/gov/types"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/atomone-hub/govgen/v1/x/gov/types"
 )
 
 func (suite *KeeperTestSuite) TestGetSetProposal() {

--- a/x/gov/keeper/querier.go
+++ b/x/gov/keeper/querier.go
@@ -1,13 +1,14 @@
 package keeper
 
 import (
-	"github.com/atomone-hub/govgen/v1/x/gov/types"
 	abci "github.com/tendermint/tendermint/abci/types"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+
+	"github.com/atomone-hub/govgen/v1/x/gov/types"
 )
 
 // NewQuerier creates a new gov Querier instance
@@ -72,8 +73,7 @@ func queryParams(ctx sdk.Context, path []string, req abci.RequestQuery, keeper K
 	}
 }
 
-//nolint: unparam
-func queryProposal(ctx sdk.Context, path []string, req abci.RequestQuery, keeper Keeper, legacyQuerierCdc *codec.LegacyAmino) ([]byte, error) {
+func queryProposal(ctx sdk.Context, path []string, req abci.RequestQuery, keeper Keeper, legacyQuerierCdc *codec.LegacyAmino) ([]byte, error) { //nolint: unparam
 	var params types.QueryProposalParams
 	err := legacyQuerierCdc.UnmarshalJSON(req.Data, &params)
 	if err != nil {
@@ -93,8 +93,7 @@ func queryProposal(ctx sdk.Context, path []string, req abci.RequestQuery, keeper
 	return bz, nil
 }
 
-//nolint: unparam
-func queryDeposit(ctx sdk.Context, path []string, req abci.RequestQuery, keeper Keeper, legacyQuerierCdc *codec.LegacyAmino) ([]byte, error) {
+func queryDeposit(ctx sdk.Context, path []string, req abci.RequestQuery, keeper Keeper, legacyQuerierCdc *codec.LegacyAmino) ([]byte, error) { //nolint: unparam
 	var params types.QueryDepositParams
 	err := legacyQuerierCdc.UnmarshalJSON(req.Data, &params)
 	if err != nil {
@@ -110,8 +109,7 @@ func queryDeposit(ctx sdk.Context, path []string, req abci.RequestQuery, keeper 
 	return bz, nil
 }
 
-//nolint: unparam
-func queryVote(ctx sdk.Context, path []string, req abci.RequestQuery, keeper Keeper, legacyQuerierCdc *codec.LegacyAmino) ([]byte, error) {
+func queryVote(ctx sdk.Context, path []string, req abci.RequestQuery, keeper Keeper, legacyQuerierCdc *codec.LegacyAmino) ([]byte, error) { //nolint: unparam
 	var params types.QueryVoteParams
 	err := legacyQuerierCdc.UnmarshalJSON(req.Data, &params)
 	if err != nil {
@@ -127,8 +125,7 @@ func queryVote(ctx sdk.Context, path []string, req abci.RequestQuery, keeper Kee
 	return bz, nil
 }
 
-//nolint: unparam
-func queryDeposits(ctx sdk.Context, path []string, req abci.RequestQuery, keeper Keeper, legacyQuerierCdc *codec.LegacyAmino) ([]byte, error) {
+func queryDeposits(ctx sdk.Context, path []string, req abci.RequestQuery, keeper Keeper, legacyQuerierCdc *codec.LegacyAmino) ([]byte, error) { //nolint: unparam
 	var params types.QueryProposalParams
 	err := legacyQuerierCdc.UnmarshalJSON(req.Data, &params)
 	if err != nil {
@@ -148,8 +145,7 @@ func queryDeposits(ctx sdk.Context, path []string, req abci.RequestQuery, keeper
 	return bz, nil
 }
 
-//nolint: unparam
-func queryTally(ctx sdk.Context, path []string, req abci.RequestQuery, keeper Keeper, legacyQuerierCdc *codec.LegacyAmino) ([]byte, error) {
+func queryTally(ctx sdk.Context, path []string, req abci.RequestQuery, keeper Keeper, legacyQuerierCdc *codec.LegacyAmino) ([]byte, error) { //nolint: unparam
 	var params types.QueryProposalParams
 	err := legacyQuerierCdc.UnmarshalJSON(req.Data, &params)
 	if err != nil {
@@ -185,8 +181,7 @@ func queryTally(ctx sdk.Context, path []string, req abci.RequestQuery, keeper Ke
 	return bz, nil
 }
 
-//nolint: unparam
-func queryVotes(ctx sdk.Context, path []string, req abci.RequestQuery, keeper Keeper, legacyQuerierCdc *codec.LegacyAmino) ([]byte, error) {
+func queryVotes(ctx sdk.Context, path []string, req abci.RequestQuery, keeper Keeper, legacyQuerierCdc *codec.LegacyAmino) ([]byte, error) { //nolint: unparam
 	var params types.QueryProposalVotesParams
 	err := legacyQuerierCdc.UnmarshalJSON(req.Data, &params)
 	if err != nil {

--- a/x/gov/keeper/querier_test.go
+++ b/x/gov/keeper/querier_test.go
@@ -6,15 +6,16 @@ import (
 	"testing"
 	"time"
 
-	govgenhelpers "github.com/atomone-hub/govgen/v1/app/helpers"
-	"github.com/atomone-hub/govgen/v1/x/gov/keeper"
-	"github.com/atomone-hub/govgen/v1/x/gov/types"
 	"github.com/stretchr/testify/require"
 	abci "github.com/tendermint/tendermint/abci/types"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	govgenhelpers "github.com/atomone-hub/govgen/v1/app/helpers"
+	"github.com/atomone-hub/govgen/v1/x/gov/keeper"
+	"github.com/atomone-hub/govgen/v1/x/gov/types"
 )
 
 const custom = "custom"

--- a/x/gov/keeper/tally.go
+++ b/x/gov/keeper/tally.go
@@ -1,10 +1,10 @@
 package keeper
 
 import (
-	"github.com/atomone-hub/govgen/v1/x/gov/types"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+
+	"github.com/atomone-hub/govgen/v1/x/gov/types"
 )
 
 // TODO: Break into several smaller functions for clarity

--- a/x/gov/keeper/tally_test.go
+++ b/x/gov/keeper/tally_test.go
@@ -3,13 +3,14 @@ package keeper_test
 import (
 	"testing"
 
-	govgenhelpers "github.com/atomone-hub/govgen/v1/app/helpers"
-	"github.com/atomone-hub/govgen/v1/x/gov/types"
 	"github.com/stretchr/testify/require"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+
+	govgenhelpers "github.com/atomone-hub/govgen/v1/app/helpers"
+	"github.com/atomone-hub/govgen/v1/x/gov/types"
 )
 
 func TestTallyNoOneVotes(t *testing.T) {

--- a/x/gov/keeper/vote.go
+++ b/x/gov/keeper/vote.go
@@ -3,10 +3,10 @@ package keeper
 import (
 	"fmt"
 
-	"github.com/atomone-hub/govgen/v1/x/gov/types"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+
+	"github.com/atomone-hub/govgen/v1/x/gov/types"
 )
 
 // AddVote adds a vote on a specific proposal

--- a/x/gov/keeper/vote_test.go
+++ b/x/gov/keeper/vote_test.go
@@ -3,12 +3,13 @@ package keeper_test
 import (
 	"testing"
 
-	govgenhelpers "github.com/atomone-hub/govgen/v1/app/helpers"
-	"github.com/atomone-hub/govgen/v1/x/gov/types"
 	"github.com/stretchr/testify/require"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	govgenhelpers "github.com/atomone-hub/govgen/v1/app/helpers"
+	"github.com/atomone-hub/govgen/v1/x/gov/types"
 )
 
 func TestVotes(t *testing.T) {

--- a/x/gov/module.go
+++ b/x/gov/module.go
@@ -8,12 +8,6 @@ import (
 	"fmt"
 	"math/rand"
 
-	govclient "github.com/atomone-hub/govgen/v1/x/gov/client"
-	"github.com/atomone-hub/govgen/v1/x/gov/client/cli"
-	govrest "github.com/atomone-hub/govgen/v1/x/gov/client/rest"
-	"github.com/atomone-hub/govgen/v1/x/gov/keeper"
-	"github.com/atomone-hub/govgen/v1/x/gov/simulation"
-	"github.com/atomone-hub/govgen/v1/x/gov/types"
 	"github.com/gorilla/mux"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/spf13/cobra"
@@ -26,6 +20,13 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/module"
 	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
 	sdkgovclient "github.com/cosmos/cosmos-sdk/x/gov/client"
+
+	govclient "github.com/atomone-hub/govgen/v1/x/gov/client"
+	"github.com/atomone-hub/govgen/v1/x/gov/client/cli"
+	govrest "github.com/atomone-hub/govgen/v1/x/gov/client/rest"
+	"github.com/atomone-hub/govgen/v1/x/gov/keeper"
+	"github.com/atomone-hub/govgen/v1/x/gov/simulation"
+	"github.com/atomone-hub/govgen/v1/x/gov/types"
 )
 
 var (

--- a/x/gov/module_test.go
+++ b/x/gov/module_test.go
@@ -3,13 +3,14 @@ package gov_test
 import (
 	"testing"
 
-	govgenhelpers "github.com/atomone-hub/govgen/v1/app/helpers"
-	"github.com/atomone-hub/govgen/v1/x/gov/types"
 	"github.com/stretchr/testify/require"
 	abcitypes "github.com/tendermint/tendermint/abci/types"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+
+	govgenhelpers "github.com/atomone-hub/govgen/v1/app/helpers"
+	"github.com/atomone-hub/govgen/v1/x/gov/types"
 )
 
 func TestItCreatesModuleAccountOnInitBlock(t *testing.T) {

--- a/x/gov/simulation/decoder.go
+++ b/x/gov/simulation/decoder.go
@@ -5,10 +5,10 @@ import (
 	"encoding/binary"
 	"fmt"
 
-	"github.com/atomone-hub/govgen/v1/x/gov/types"
-
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/types/kv"
+
+	"github.com/atomone-hub/govgen/v1/x/gov/types"
 )
 
 // NewDecodeStore returns a decoder function closure that unmarshals the KVPair's

--- a/x/gov/simulation/decoder_test.go
+++ b/x/gov/simulation/decoder_test.go
@@ -6,14 +6,15 @@ import (
 	"testing"
 	"time"
 
-	govgenapp "github.com/atomone-hub/govgen/v1/app"
-	"github.com/atomone-hub/govgen/v1/x/gov/simulation"
-	"github.com/atomone-hub/govgen/v1/x/gov/types"
 	"github.com/stretchr/testify/require"
 
 	"github.com/cosmos/cosmos-sdk/crypto/keys/ed25519"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/kv"
+
+	govgenapp "github.com/atomone-hub/govgen/v1/app"
+	"github.com/atomone-hub/govgen/v1/x/gov/simulation"
+	"github.com/atomone-hub/govgen/v1/x/gov/types"
 )
 
 var (

--- a/x/gov/simulation/genesis.go
+++ b/x/gov/simulation/genesis.go
@@ -8,11 +8,11 @@ import (
 	"math/rand"
 	"time"
 
-	"github.com/atomone-hub/govgen/v1/x/gov/types"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	"github.com/cosmos/cosmos-sdk/types/simulation"
+
+	"github.com/atomone-hub/govgen/v1/x/gov/types"
 )
 
 // Simulation parameter constants

--- a/x/gov/simulation/genesis_test.go
+++ b/x/gov/simulation/genesis_test.go
@@ -5,8 +5,6 @@ import (
 	"math/rand"
 	"testing"
 
-	"github.com/atomone-hub/govgen/v1/x/gov/simulation"
-	"github.com/atomone-hub/govgen/v1/x/gov/types"
 	"github.com/stretchr/testify/require"
 
 	"github.com/cosmos/cosmos-sdk/codec"
@@ -14,6 +12,9 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
+
+	"github.com/atomone-hub/govgen/v1/x/gov/simulation"
+	"github.com/atomone-hub/govgen/v1/x/gov/types"
 )
 
 // TestRandomizedGenState tests the normal scenario of applying RandomizedGenState.

--- a/x/gov/simulation/operations.go
+++ b/x/gov/simulation/operations.go
@@ -5,16 +5,16 @@ import (
 	"math/rand"
 	"time"
 
-	appparams "github.com/atomone-hub/govgen/v1/app/params"
-	"github.com/atomone-hub/govgen/v1/x/gov/keeper"
-	"github.com/atomone-hub/govgen/v1/x/gov/types"
-
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/simapp/helpers"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
 	"github.com/cosmos/cosmos-sdk/x/simulation"
+
+	appparams "github.com/atomone-hub/govgen/v1/app/params"
+	"github.com/atomone-hub/govgen/v1/x/gov/keeper"
+	"github.com/atomone-hub/govgen/v1/x/gov/types"
 )
 
 var initialProposalID = uint64(100000000000000)

--- a/x/gov/simulation/operations_test.go
+++ b/x/gov/simulation/operations_test.go
@@ -6,11 +6,6 @@ import (
 	"testing"
 	"time"
 
-	govgenapp "github.com/atomone-hub/govgen/v1/app"
-	govgenhelpers "github.com/atomone-hub/govgen/v1/app/helpers"
-	appparams "github.com/atomone-hub/govgen/v1/app/params"
-	"github.com/atomone-hub/govgen/v1/x/gov/simulation"
-	"github.com/atomone-hub/govgen/v1/x/gov/types"
 	"github.com/stretchr/testify/require"
 	abci "github.com/tendermint/tendermint/abci/types"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
@@ -18,6 +13,12 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
 	minttypes "github.com/cosmos/cosmos-sdk/x/mint/types"
+
+	govgenapp "github.com/atomone-hub/govgen/v1/app"
+	govgenhelpers "github.com/atomone-hub/govgen/v1/app/helpers"
+	appparams "github.com/atomone-hub/govgen/v1/app/params"
+	"github.com/atomone-hub/govgen/v1/x/gov/simulation"
+	"github.com/atomone-hub/govgen/v1/x/gov/types"
 )
 
 type MockWeightedProposalContent struct {

--- a/x/gov/simulation/params.go
+++ b/x/gov/simulation/params.go
@@ -7,11 +7,11 @@ import (
 	"fmt"
 	"math/rand"
 
-	"github.com/atomone-hub/govgen/v1/x/gov/types"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
 	"github.com/cosmos/cosmos-sdk/x/simulation"
+
+	"github.com/atomone-hub/govgen/v1/x/gov/types"
 )
 
 const (

--- a/x/gov/simulation/params_test.go
+++ b/x/gov/simulation/params_test.go
@@ -4,8 +4,9 @@ import (
 	"math/rand"
 	"testing"
 
-	"github.com/atomone-hub/govgen/v1/x/gov/simulation"
 	"github.com/stretchr/testify/require"
+
+	"github.com/atomone-hub/govgen/v1/x/gov/simulation"
 )
 
 func TestParamChanges(t *testing.T) {

--- a/x/gov/simulation/proposals.go
+++ b/x/gov/simulation/proposals.go
@@ -3,12 +3,12 @@ package simulation
 import (
 	"math/rand"
 
-	appparams "github.com/atomone-hub/govgen/v1/app/params"
-	"github.com/atomone-hub/govgen/v1/x/gov/types"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
 	"github.com/cosmos/cosmos-sdk/x/simulation"
+
+	appparams "github.com/atomone-hub/govgen/v1/app/params"
+	"github.com/atomone-hub/govgen/v1/x/gov/types"
 )
 
 // OpWeightSubmitTextProposal app params key for text proposal

--- a/x/gov/simulation/proposals_test.go
+++ b/x/gov/simulation/proposals_test.go
@@ -4,13 +4,14 @@ import (
 	"math/rand"
 	"testing"
 
-	appparams "github.com/atomone-hub/govgen/v1/app/params"
-	"github.com/atomone-hub/govgen/v1/x/gov/simulation"
 	"github.com/stretchr/testify/require"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
+
+	appparams "github.com/atomone-hub/govgen/v1/app/params"
+	"github.com/atomone-hub/govgen/v1/x/gov/simulation"
 )
 
 func TestProposalContents(t *testing.T) {


### PR DESCRIPTION
- fix govgen import path in gci tool configuration in  the `.golangci.yml` file
- fix import order in respect of that configuration (`make format` can do that automatically)
- fix usage of `//nolint: unparam`

Not sure if we should target `feat/custom-gov-module` or `main` branch, give me your though!