### PR TITLE
fix: Update go.mod

### DIFF
--- a/ante/ante.go
+++ b/ante/ante.go
@@ -9,7 +9,7 @@ import (
 	govkeeper "github.com/cosmos/cosmos-sdk/x/gov/keeper"
 	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
 
-	"github.com/atomone-hub/govgen/v1/types/errors"
+	"github.com/atomone-hub/govgen/types/errors"
 )
 
 // HandlerOptions extend the SDK's AnteHandler options by requiring the IBC

--- a/ante/fee_test.go
+++ b/ante/fee_test.go
@@ -17,9 +17,9 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/tx/signing"
 	xauthsigning "github.com/cosmos/cosmos-sdk/x/auth/signing"
 
-	"github.com/atomone-hub/govgen/v1/ante"
-	govgenapp "github.com/atomone-hub/govgen/v1/app"
-	govgenhelpers "github.com/atomone-hub/govgen/v1/app/helpers"
+	"github.com/atomone-hub/govgen/ante"
+	govgenapp "github.com/atomone-hub/govgen/app"
+	govgenhelpers "github.com/atomone-hub/govgen/app/helpers"
 )
 
 type FeeIntegrationTestSuite struct {

--- a/ante/gov_ante.go
+++ b/ante/gov_ante.go
@@ -9,7 +9,7 @@ import (
 	govkeeper "github.com/cosmos/cosmos-sdk/x/gov/keeper"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 
-	"github.com/atomone-hub/govgen/v1/types/errors"
+	"github.com/atomone-hub/govgen/types/errors"
 )
 
 // initial deposit must be greater than or equal to 1% of the minimum deposit

--- a/ante/gov_ante_test.go
+++ b/ante/gov_ante_test.go
@@ -13,9 +13,9 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 
-	"github.com/atomone-hub/govgen/v1/ante"
-	govgenapp "github.com/atomone-hub/govgen/v1/app"
-	govgenhelpers "github.com/atomone-hub/govgen/v1/app/helpers"
+	"github.com/atomone-hub/govgen/ante"
+	govgenapp "github.com/atomone-hub/govgen/app"
+	govgenhelpers "github.com/atomone-hub/govgen/app/helpers"
 )
 
 var (

--- a/app/app.go
+++ b/app/app.go
@@ -42,10 +42,10 @@ import (
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 
-	govgenante "github.com/atomone-hub/govgen/v1/ante"
-	"github.com/atomone-hub/govgen/v1/app/keepers"
-	govgenappparams "github.com/atomone-hub/govgen/v1/app/params"
-	"github.com/atomone-hub/govgen/v1/app/upgrades"
+	govgenante "github.com/atomone-hub/govgen/ante"
+	"github.com/atomone-hub/govgen/app/keepers"
+	govgenappparams "github.com/atomone-hub/govgen/app/params"
+	"github.com/atomone-hub/govgen/app/upgrades"
 )
 
 var (

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -10,8 +10,8 @@ import (
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 
-	govgen "github.com/atomone-hub/govgen/v1/app"
-	govgenhelpers "github.com/atomone-hub/govgen/v1/app/helpers"
+	govgen "github.com/atomone-hub/govgen/app"
+	govgenhelpers "github.com/atomone-hub/govgen/app/helpers"
 )
 
 type EmptyAppOptions struct{}

--- a/app/encoding.go
+++ b/app/encoding.go
@@ -3,7 +3,7 @@ package govgen
 import (
 	"github.com/cosmos/cosmos-sdk/std"
 
-	"github.com/atomone-hub/govgen/v1/app/params"
+	"github.com/atomone-hub/govgen/app/params"
 )
 
 // MakeTestEncodingConfig creates an EncodingConfig for testing. This function

--- a/app/helpers/test_helpers.go
+++ b/app/helpers/test_helpers.go
@@ -22,7 +22,7 @@ import (
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 
-	govgenapp "github.com/atomone-hub/govgen/v1/app"
+	govgenapp "github.com/atomone-hub/govgen/app"
 )
 
 // SimAppChainID hardcoded chainID for simulation

--- a/app/modules.go
+++ b/app/modules.go
@@ -39,7 +39,7 @@ import (
 	upgradeclient "github.com/cosmos/cosmos-sdk/x/upgrade/client"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 
-	govgenappparams "github.com/atomone-hub/govgen/v1/app/params"
+	govgenappparams "github.com/atomone-hub/govgen/app/params"
 )
 
 var maccPerms = map[string][]string{

--- a/app/sim/sim_state.go
+++ b/app/sim/sim_state.go
@@ -21,7 +21,7 @@ import (
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 
-	govgen "github.com/atomone-hub/govgen/v1/app"
+	govgen "github.com/atomone-hub/govgen/app"
 )
 
 // AppStateFn returns the initial application state using a genesis or the simulation parameters.

--- a/app/sim/sim_utils.go
+++ b/app/sim/sim_utils.go
@@ -15,7 +15,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/module"
 	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
 
-	govgen "github.com/atomone-hub/govgen/v1/app"
+	govgen "github.com/atomone-hub/govgen/app"
 )
 
 // SetupSimulation creates the config, db (levelDB), temporary directory and logger for

--- a/app/sim_test.go
+++ b/app/sim_test.go
@@ -17,10 +17,10 @@ import (
 	simulation2 "github.com/cosmos/cosmos-sdk/types/simulation"
 	"github.com/cosmos/cosmos-sdk/x/simulation"
 
-	govgen "github.com/atomone-hub/govgen/v1/app"
-	"github.com/atomone-hub/govgen/v1/app/helpers"
-	"github.com/atomone-hub/govgen/v1/app/params"
-	"github.com/atomone-hub/govgen/v1/app/sim"
+	govgen "github.com/atomone-hub/govgen/app"
+	"github.com/atomone-hub/govgen/app/helpers"
+	"github.com/atomone-hub/govgen/app/params"
+	"github.com/atomone-hub/govgen/app/sim"
 )
 
 func init() {

--- a/app/upgrades/types.go
+++ b/app/upgrades/types.go
@@ -6,7 +6,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/module"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 
-	"github.com/atomone-hub/govgen/v1/app/keepers"
+	"github.com/atomone-hub/govgen/app/keepers"
 )
 
 // Upgrade defines a struct containing necessary fields that a SoftwareUpgradeProposal

--- a/cmd/govgend/cmd/bech32_convert.go
+++ b/cmd/govgend/cmd/bech32_convert.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	addressutil "github.com/atomone-hub/govgen/v1/pkg/address"
+	addressutil "github.com/atomone-hub/govgen/pkg/address"
 )
 
 var flagBech32Prefix = "prefix"

--- a/cmd/govgend/cmd/root.go
+++ b/cmd/govgend/cmd/root.go
@@ -31,8 +31,8 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/crisis"
 	genutilcli "github.com/cosmos/cosmos-sdk/x/genutil/client/cli"
 
-	govgen "github.com/atomone-hub/govgen/v1/app"
-	"github.com/atomone-hub/govgen/v1/app/params"
+	govgen "github.com/atomone-hub/govgen/app"
+	"github.com/atomone-hub/govgen/app/params"
 )
 
 // NewRootCmd creates a new root command for simd. It is called once in the

--- a/cmd/govgend/cmd/root_test.go
+++ b/cmd/govgend/cmd/root_test.go
@@ -7,8 +7,8 @@ import (
 
 	svrcmd "github.com/cosmos/cosmos-sdk/server/cmd"
 
-	app "github.com/atomone-hub/govgen/v1/app"
-	"github.com/atomone-hub/govgen/v1/cmd/govgend/cmd"
+	app "github.com/atomone-hub/govgen/app"
+	"github.com/atomone-hub/govgen/cmd/govgend/cmd"
 )
 
 func TestRootCmdConfig(t *testing.T) {

--- a/cmd/govgend/main.go
+++ b/cmd/govgend/main.go
@@ -6,8 +6,8 @@ import (
 	"github.com/cosmos/cosmos-sdk/server"
 	svrcmd "github.com/cosmos/cosmos-sdk/server/cmd"
 
-	app "github.com/atomone-hub/govgen/v1/app"
-	"github.com/atomone-hub/govgen/v1/cmd/govgend/cmd"
+	app "github.com/atomone-hub/govgen/app"
+	"github.com/atomone-hub/govgen/cmd/govgend/cmd"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/atomone-hub/govgen/v1
+module github.com/atomone-hub/govgen
 
 go 1.20
 


### PR DESCRIPTION
If less than v2, 

the `module <module_path>/v{x}` syntax should not be used

Otherwise: 
`invalid version: go.mod has malformed module path "github.com/atomone-hub/govgen/v1" at revision 0a1cf4775e8b`