### PR TITLE
test: improve vote inheritance testing

### DIFF
--- a/x/gov/keeper/tally.go
+++ b/x/gov/keeper/tally.go
@@ -71,6 +71,8 @@ func (keeper Keeper) Tally(ctx sdk.Context, proposal types.Proposal) (passes boo
 		return false
 	})
 
+	/* DISABLED on GovGen - Voting can only be done with your own stake
+
 	// iterate over the validators again to tally their voting power
 	for _, val := range currValidators {
 		if len(val.Vote) == 0 {
@@ -86,6 +88,8 @@ func (keeper Keeper) Tally(ctx sdk.Context, proposal types.Proposal) (passes boo
 		}
 		totalVotingPower = totalVotingPower.Add(votingPower)
 	}
+
+	*/
 
 	tallyParams := keeper.GetTallyParams(ctx)
 	tallyResults = types.NewTallyResultFromMap(results)

--- a/x/gov/keeper/tally.go
+++ b/x/gov/keeper/tally.go
@@ -71,8 +71,6 @@ func (keeper Keeper) Tally(ctx sdk.Context, proposal types.Proposal) (passes boo
 		return false
 	})
 
-	/* DISABLED on GovGen - Voting can only be done with your own stake
-
 	// iterate over the validators again to tally their voting power
 	for _, val := range currValidators {
 		if len(val.Vote) == 0 {
@@ -88,8 +86,6 @@ func (keeper Keeper) Tally(ctx sdk.Context, proposal types.Proposal) (passes boo
 		}
 		totalVotingPower = totalVotingPower.Add(votingPower)
 	}
-
-	*/
 
 	tallyParams := keeper.GetTallyParams(ctx)
 	tallyResults = types.NewTallyResultFromMap(results)

--- a/x/gov/keeper/tally_test.go
+++ b/x/gov/keeper/tally_test.go
@@ -281,7 +281,8 @@ func TestTallyDelgatorInherit(t *testing.T) {
 	app := govgenhelpers.SetupNoValset(false)
 	ctx := app.BaseApp.NewContext(false, tmproto.Header{})
 
-	addrs, vals := createValidators(t, ctx, app, []int64{5, 6, 7})
+	valPowers := []int64{5, 6, 7}
+	addrs, vals := createValidators(t, ctx, app, valPowers)
 
 	delTokens := app.StakingKeeper.TokensFromConsensusPower(ctx, 30)
 	val3, found := app.StakingKeeper.GetValidator(ctx, vals[2])
@@ -307,16 +308,27 @@ func TestTallyDelgatorInherit(t *testing.T) {
 	require.True(t, ok)
 	passes, burnDeposits, tallyResults := app.GovKeeper.Tally(ctx, proposal)
 
-	require.False(t, passes)
+	require.True(t, passes)
 	require.False(t, burnDeposits)
-	require.False(t, tallyResults.Equals(types.EmptyTallyResult()))
+	valSelfDelegations := []sdk.Int{
+		app.StakingKeeper.TokensFromConsensusPower(ctx, valPowers[0]),
+		app.StakingKeeper.TokensFromConsensusPower(ctx, valPowers[1]),
+		app.StakingKeeper.TokensFromConsensusPower(ctx, valPowers[2]),
+	}
+	require.Equal(t, tallyResults.String(), types.NewTallyResult(
+		valSelfDelegations[2].Add(delTokens),
+		sdk.ZeroInt(),
+		valSelfDelegations[0].Add(valSelfDelegations[1]),
+		sdk.ZeroInt(),
+	).String())
 }
 
 func TestTallyDelgatorMultipleOverride(t *testing.T) {
 	app := govgenhelpers.SetupNoValset(false)
 	ctx := app.BaseApp.NewContext(false, tmproto.Header{})
 
-	addrs, vals := createValidators(t, ctx, app, []int64{5, 6, 7})
+	valPowers := []int64{5, 6, 7}
+	addrs, vals := createValidators(t, ctx, app, valPowers)
 
 	delTokens := app.StakingKeeper.TokensFromConsensusPower(ctx, 10)
 	val1, found := app.StakingKeeper.GetValidator(ctx, vals[0])
@@ -349,7 +361,17 @@ func TestTallyDelgatorMultipleOverride(t *testing.T) {
 
 	require.False(t, passes)
 	require.False(t, burnDeposits)
-	require.False(t, tallyResults.Equals(types.EmptyTallyResult()))
+	valSelfDelegations := []sdk.Int{
+		app.StakingKeeper.TokensFromConsensusPower(ctx, valPowers[0]),
+		app.StakingKeeper.TokensFromConsensusPower(ctx, valPowers[1]),
+		app.StakingKeeper.TokensFromConsensusPower(ctx, valPowers[2]),
+	}
+	require.Equal(t, tallyResults.String(), types.NewTallyResult(
+		valSelfDelegations[0].Add(valSelfDelegations[1]).Add(valSelfDelegations[2]),
+		sdk.ZeroInt(),
+		delTokens.Add(delTokens),
+		sdk.ZeroInt(),
+	).String())
 }
 
 // As validators can only vote with their own stake, delegators don't inherit votes from validators
@@ -358,9 +380,8 @@ func TestTallyDelgatorMultipleInherit(t *testing.T) {
 	app := govgenhelpers.SetupNoValset(false)
 	ctx := app.BaseApp.NewContext(false, tmproto.Header{})
 
-	createValidators(t, ctx, app, []int64{25, 6, 7})
-
-	addrs, vals := createValidators(t, ctx, app, []int64{5, 6, 7})
+	valPowers := []int64{5, 6, 7}
+	addrs, vals := createValidators(t, ctx, app, valPowers)
 
 	delTokens := app.StakingKeeper.TokensFromConsensusPower(ctx, 10)
 	val2, found := app.StakingKeeper.GetValidator(ctx, vals[1])
@@ -390,9 +411,19 @@ func TestTallyDelgatorMultipleInherit(t *testing.T) {
 	require.True(t, ok)
 	passes, burnDeposits, tallyResults := app.GovKeeper.Tally(ctx, proposal)
 
-	require.True(t, passes)
+	require.False(t, passes)
 	require.False(t, burnDeposits)
-	require.False(t, tallyResults.Equals(types.EmptyTallyResult()))
+	valSelfDelegations := []sdk.Int{
+		app.StakingKeeper.TokensFromConsensusPower(ctx, valPowers[0]),
+		app.StakingKeeper.TokensFromConsensusPower(ctx, valPowers[1]),
+		app.StakingKeeper.TokensFromConsensusPower(ctx, valPowers[2]),
+	}
+	require.Equal(t, tallyResults.String(), types.NewTallyResult(
+		valSelfDelegations[0],
+		sdk.ZeroInt(),
+		valSelfDelegations[1].Add(valSelfDelegations[2]).Add(delTokens).Add(delTokens),
+		sdk.ZeroInt(),
+	).String())
 }
 
 func TestTallyJailedValidator(t *testing.T) {

--- a/x/gov/keeper/tally_test.go
+++ b/x/gov/keeper/tally_test.go
@@ -308,7 +308,7 @@ func TestTallyDelgatorInherit(t *testing.T) {
 	require.True(t, ok)
 	passes, burnDeposits, tallyResults := app.GovKeeper.Tally(ctx, proposal)
 
-	require.True(t, passes)
+	require.False(t, passes)
 	require.False(t, burnDeposits)
 	valSelfDelegations := []sdk.Int{
 		app.StakingKeeper.TokensFromConsensusPower(ctx, valPowers[0]),
@@ -316,7 +316,7 @@ func TestTallyDelgatorInherit(t *testing.T) {
 		app.StakingKeeper.TokensFromConsensusPower(ctx, valPowers[2]),
 	}
 	require.Equal(t, tallyResults.String(), types.NewTallyResult(
-		valSelfDelegations[2].Add(delTokens),
+		valSelfDelegations[2],
 		sdk.ZeroInt(),
 		valSelfDelegations[0].Add(valSelfDelegations[1]),
 		sdk.ZeroInt(),
@@ -421,7 +421,7 @@ func TestTallyDelgatorMultipleInherit(t *testing.T) {
 	require.Equal(t, tallyResults.String(), types.NewTallyResult(
 		valSelfDelegations[0],
 		sdk.ZeroInt(),
-		valSelfDelegations[1].Add(valSelfDelegations[2]).Add(delTokens).Add(delTokens),
+		valSelfDelegations[1].Add(valSelfDelegations[2]),
 		sdk.ZeroInt(),
 	).String())
 }


### PR DESCRIPTION
While reviewing #20, I found that the tally result assertion was weak, since it only ensures that the expected tally result is not empty. 

This change improves that for tests that imply vote inheritance, the first commit e257af4396268284d0b382103ce754b481d2fe12 re-enables vote inheritance and improves the tally result assertion. The second commit 3696c7cf6c1f7178ad365af0fc9075db4cbc8b34 disables vote inheritance again and updates the assertions to show that vote inheritance is correctly disabled (removing the `delTokens` additions in the expected tally results).