### PR TITLE
feat: `InitChainer` auto stakes uniformly to validators at genesis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
   ([#13](https://github.com/atomone-hub/govgen/pull/13)).
 * Adapt voting period to proposal type.
   ([#16](https://github.com/atomone-hub/govgen/pull/16)).
-* Auto stake genesis accounts
+* `InitChainer` auto stakes uniformly to validators at genesis
   ([#26](https://github.com/atomone-hub/govgen/pull/26)).
 
 ### STATE BREAKING

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,5 +20,7 @@
   ([#13](https://github.com/atomone-hub/govgen/pull/13)).
 * Adapt voting period to proposal type.
   ([#16](https://github.com/atomone-hub/govgen/pull/16)).
+* Auto stake genesis accounts
+  ([#26](https://github.com/atomone-hub/govgen/pull/26)).
 
 ### STATE BREAKING

--- a/README.md
+++ b/README.md
@@ -14,4 +14,5 @@ The following modifications have been made to the Cosmos Hub software to create 
     7. Removed ability for validators to vote on proposals with delegations, they can only use their own stake
     8. Removed community spend proposal
     9. Allowed setting different voting periods for different proposal types
-   10. Auto stake genesis accounts
+   10. Stake automatically 50% of balance for accounts that have more than 25 $GOVGEN at genesis initialization. The resulting stake distribution will provide approximately the same voting power to all genesis validators. Accounts will automatically stake to 5 validators if balance is less than 500 $GOVGEN, 10 validators if balance is less than 10000 $GOVGEN and 20 validators if more, uniformly.
+   

--- a/README.md
+++ b/README.md
@@ -14,3 +14,4 @@ The following modifications have been made to the Cosmos Hub software to create 
     7. Removed ability for validators to vote on proposals with delegations, they can only use their own stake
     8. Removed community spend proposal
     9. Allowed setting different voting periods for different proposal types
+   10. Auto stake genesis accounts

--- a/x/gov/module_test.go
+++ b/x/gov/module_test.go
@@ -19,7 +19,8 @@ func TestItCreatesModuleAccountOnInitBlock(t *testing.T) {
 
 	app.InitChain(
 		abcitypes.RequestInitChain{
-			AppStateBytes: []byte("{}"),
+			// bank module must be present because of app.setInitialStakingDistribution
+			AppStateBytes: []byte(`{"bank":{}}`),
 			ChainId:       "test-chain-id",
 		},
 	)


### PR DESCRIPTION
Stake automatically 50% of balance for accounts that have more than 25 $GOVGEN at genesis initialization. The resulting stake distribution will provide approximately the same voting power to all genesis validators. Accounts will automatically stake to 5 validators if balance is less than 500 $GOVGEN, 10 validators if balance is less than 10000 $GOVGEN and 20 validators if more, uniformly.