### PR TITLE
doc: fix staking condition

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,14 @@ GovGen is built using the [Cosmos SDK](https://github.com/cosmos/cosmos-sdk) as 
 
 The following modifications have been made to the Cosmos Hub software to create GovGen:
 
-    1. Removed x/globalfee module and revert to older and simpler fee decorator
-    2. Removed IBC and related modules (e.g. ICA, Packet Forwarding Middleware, etc.)
-    3. Removed Interchain Security module
-    4. Reverted to standard Cosmos SDK v0.46.16 without the Liquid Staking Module (LSM)
-    5. Changed Bech32 prefixes to `govgen` (see `cmd/govgend/cmd/config.go`)
-    6. Reduced hard-coded ante min-deposit percentage to 1% (see `ante/gov_ante.go:minInitialDepositFraction`)
-    7. Removed ability for validators to vote on proposals with delegations, they can only use their own stake
-    8. Removed community spend proposal
-    9. Allowed setting different voting periods for different proposal types
-    10. Stake automatically 50% of balance for accounts that have more than 25 $GOVGEN at genesis initialization. The resulting stake distribution will provide approximately the same voting power to all genesis validators. Accounts will automatically stake to 5 validators if balance is less than 500 $GOVGEN, 10 validators if balance is less than 10000 $GOVGEN and 20 validators if more, uniformly.
+1. Removed x/globalfee module and revert to older and simpler fee decorator
+2. Removed IBC and related modules (e.g. ICA, Packet Forwarding Middleware, etc.)
+3. Removed Interchain Security module
+4. Reverted to standard Cosmos SDK v0.46.16 without the Liquid Staking Module (LSM)
+5. Changed Bech32 prefixes to `govgen` (see `cmd/govgend/cmd/config.go`)
+6. Reduced hard-coded ante min-deposit percentage to 1% (see `ante/gov_ante.go:minInitialDepositFraction`)
+7. Removed ability for validators to vote on proposals with delegations, they can only use their own stake
+8. Removed community spend proposal
+9. Allowed setting different voting periods for different proposal types
+10. Stake automatically 50% of balance for accounts that have more than 25 $GOVGEN at genesis initialization. The resulting stake distribution will provide approximately the same voting power to all genesis validators. Accounts will automatically stake to 5 validators if 50% of the balance is less than 500 $GOVGEN, 10 validators if less than 10000 $GOVGEN and 20 validators if more, uniformly.
    


### PR DESCRIPTION
The determination of the number of validators is based on the 50% of the balance, not the total balance.

Also remove indentation that created a fenced code format.

