### PR TITLE
test: initial staking distribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,5 +14,4 @@ The following modifications have been made to the Cosmos Hub software to create 
 7. Removed ability for validators to vote on proposals with delegations, they can only use their own stake
 8. Removed community spend proposal
 9. Allowed setting different voting periods for different proposal types
-10. Stake automatically 50% of balance for accounts that have more than 25 $GOVGEN at genesis initialization. The resulting stake distribution will provide approximately the same voting power to all genesis validators. Accounts will automatically stake to 5 validators if balance is less than 500 $GOVGEN, 10 validators if balance is less than 10000 $GOVGEN and 20 validators if more, uniformly.
-   
+10. Stake automatically 50% of balance for accounts that have more than 25 $GOVGEN at genesis initialization. The resulting stake distribution will provide approximately the same voting power to all genesis validators. Accounts will automatically stake to a maximum of 5 validators if 50% of the balance is less than 500 $GOVGEN, a maximum of 10 validators if less than 10,000 $GOVGEN and a maximum of 20 validators if more, uniformly. The number of validators elected for the delegations is not a constant because it depends on the state of the distribution.

--- a/app/app.go
+++ b/app/app.go
@@ -237,6 +237,7 @@ func (app *GovGenApp) EndBlocker(ctx sdk.Context, req abci.RequestEndBlock) abci
 
 // InitChainer application update at chain initialization
 func (app *GovGenApp) InitChainer(ctx sdk.Context, req abci.RequestInitChain) abci.ResponseInitChain {
+	fmt.Println("INIT CHAINER")
 	var genesisState GenesisState
 	if err := tmjson.Unmarshal(req.AppStateBytes, &genesisState); err != nil {
 		panic(err)
@@ -257,6 +258,10 @@ func (app *GovGenApp) InitChainer(ctx sdk.Context, req abci.RequestInitChain) ab
 func (app *GovGenApp) setInitialStakingDistribution(ctx sdk.Context, genesisState GenesisState) {
 	var bankState banktypes.GenesisState
 	app.appCodec.MustUnmarshalJSON(genesisState[banktypes.ModuleName], &bankState)
+	if len(bankState.Balances) == 0 {
+		// no balances, skip
+		return
+	}
 	// Sort balances in descending order
 	sort.Slice(bankState.Balances, func(i, j int) bool {
 		return bankState.Balances[i].Coins.IsAllGT(bankState.Balances[j].Coins)
@@ -277,6 +282,7 @@ func (app *GovGenApp) setInitialStakingDistribution(ctx sdk.Context, genesisStat
 			Validator: val,
 		})
 	}
+	fmt.Println("VALS", len(validators))
 	if len(validators) == 0 {
 		return
 	}

--- a/app/app.go
+++ b/app/app.go
@@ -237,7 +237,6 @@ func (app *GovGenApp) EndBlocker(ctx sdk.Context, req abci.RequestEndBlock) abci
 
 // InitChainer application update at chain initialization
 func (app *GovGenApp) InitChainer(ctx sdk.Context, req abci.RequestInitChain) abci.ResponseInitChain {
-	fmt.Println("INIT CHAINER")
 	var genesisState GenesisState
 	if err := tmjson.Unmarshal(req.AppStateBytes, &genesisState); err != nil {
 		panic(err)

--- a/app/app.go
+++ b/app/app.go
@@ -266,7 +266,9 @@ func (app *GovGenApp) setInitialStakingDistribution(ctx sdk.Context, genesisStat
 	}
 	// Sort balances in descending order
 	sort.Slice(bankState.Balances, func(i, j int) bool {
-		return bankState.Balances[i].Coins.IsAllGT(bankState.Balances[j].Coins)
+		coin1 := bankState.Balances[i].Coins.AmountOf("ugovgen")
+		coin2 := bankState.Balances[j].Coins.AmountOf("ugovgen")
+		return coin1.GT(coin2)
 	})
 
 	var (
@@ -284,7 +286,6 @@ func (app *GovGenApp) setInitialStakingDistribution(ctx sdk.Context, genesisStat
 			Validator: val,
 		})
 	}
-	fmt.Println("VALS", len(validators))
 	if len(validators) == 0 {
 		return
 	}

--- a/app/app.go
+++ b/app/app.go
@@ -278,6 +278,8 @@ func (app *GovGenApp) setInitialStakingDistribution(ctx sdk.Context, genesisStat
 	// Extend validator to track delegations
 	type validator struct {
 		stakingtypes.Validator
+		// FIXME(tb): should be replaceable by validator.DelegatorShares field
+		// (so no need for custom struct)
 		totalDelegations int64
 	}
 	var validators []*validator

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -68,8 +68,8 @@ func TestGovGenApp_InitialStakingDistribution(t *testing.T) {
 		balance := banktypes.Balance{
 			Address: acc.GetAddress().String(),
 			Coins: sdk.NewCoins(
+				// randomize govgen distribution amoung the accounts
 				sdk.NewCoin("ugovgen", sdk.NewInt(1_000_000*tmrand.Int63n(1_000_000))),
-				// sdk.NewCoin("ugovgen", sdk.NewInt(1_000_000_000_000)),
 				sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(100_000_000_000_000)),
 			),
 		}

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -68,7 +68,7 @@ func TestGovGenApp_InitialStakingDistribution(t *testing.T) {
 		balance := banktypes.Balance{
 			Address: acc.GetAddress().String(),
 			Coins: sdk.NewCoins(
-				// randomize govgen distribution amoung the accounts
+				// randomize govgen distribution among the accounts
 				sdk.NewCoin("ugovgen", sdk.NewInt(1_000_000*tmrand.Int63n(1_000_000))),
 				sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(100_000_000_000_000)),
 			),

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -1,13 +1,19 @@
 package govgen_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"github.com/tendermint/tendermint/libs/log"
+	tmrand "github.com/tendermint/tendermint/libs/rand"
+	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
+	tmtypes "github.com/tendermint/tendermint/types"
 	db "github.com/tendermint/tm-db"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 
 	govgen "github.com/atomone-hub/govgen/app"
 	govgenhelpers "github.com/atomone-hub/govgen/app/helpers"
@@ -42,4 +48,45 @@ func TestGovGenApp_Export(t *testing.T) {
 	app := govgenhelpers.Setup(t)
 	_, err := app.ExportAppStateAndValidators(true, []string{})
 	require.NoError(t, err, "ExportAppStateAndValidators should not have an error")
+}
+
+func TestGovGenApp_InitialStakingDistribution(t *testing.T) {
+	// generate 30 validators and 100 genesis accounts
+	var (
+		valset, _       = tmtypes.RandValidatorSet(20, 1)
+		genesisAccounts []authtypes.GenesisAccount
+		balances        []banktypes.Balance
+	)
+	for i := 0; i < 100; i++ {
+		senderPrivKey := govgenhelpers.NewPV()
+		senderPubKey := senderPrivKey.PrivKey.PubKey()
+		acc := authtypes.NewBaseAccount(senderPubKey.Address().Bytes(), senderPubKey, 0, 0)
+		balance := banktypes.Balance{
+			Address: acc.GetAddress().String(),
+			Coins: sdk.NewCoins(
+				sdk.NewCoin("ugovgen", sdk.NewInt(100_000_000_000_000)),
+				sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(100_000_000_000_000)),
+			),
+		}
+		// if i == 0 {
+		// balance.Coins = balance.Coins.Add(
+		// sdk.NewInt64Coin(sdk.DefaultBondDenom, int64(1_000_000*len(valset.Validators))),
+		// sdk.NewInt64Coin(sdk.DefaultBondDenom, 1_000_000),
+		// )
+		// }
+		balances = append(balances, balance)
+		genesisAccounts = append(genesisAccounts, acc)
+	}
+	app := govgenhelpers.SetupWithGenesisValSet(t, valset, genesisAccounts, balances...)
+	ctx := app.BaseApp.NewContext(false, tmproto.Header{
+		ChainID: fmt.Sprintf("test-chain-%s", tmrand.Str(4)),
+		Height:  1,
+	})
+
+	// encodingConfig := gaiaapp.MakeTestEncodingConfig()
+	// encodingConfig.Amino.RegisterConcrete(&testdata.TestMsg{}, "testdata.TestMsg", nil)
+	// testdata.RegisterInterfaces(encodingConfig.InterfaceRegistry)
+
+	delegations := app.StakingKeeper.GetAllDelegations(ctx)
+	fmt.Println(delegations)
 }

--- a/app/helpers/test_helpers.go
+++ b/app/helpers/test_helpers.go
@@ -220,11 +220,13 @@ func genesisStateWithValSet(t *testing.T,
 		// add genesis acc tokens to total supply
 		totalSupply = totalSupply.Add(b.Coins...)
 	}
+	fmt.Println("SUPPLY1", totalSupply)
 
 	for range delegations {
 		// add delegated tokens to total supply
 		totalSupply = totalSupply.Add(sdk.NewCoin(sdk.DefaultBondDenom, bondAmt))
 	}
+	fmt.Println("SUPPLY2", totalSupply)
 
 	// add bonded amount to bonded pool module account
 	balances = append(balances, banktypes.Balance{

--- a/app/helpers/test_helpers.go
+++ b/app/helpers/test_helpers.go
@@ -220,18 +220,17 @@ func genesisStateWithValSet(t *testing.T,
 		// add genesis acc tokens to total supply
 		totalSupply = totalSupply.Add(b.Coins...)
 	}
-	fmt.Println("SUPPLY1", totalSupply)
 
 	for range delegations {
 		// add delegated tokens to total supply
 		totalSupply = totalSupply.Add(sdk.NewCoin(sdk.DefaultBondDenom, bondAmt))
 	}
-	fmt.Println("SUPPLY2", totalSupply)
 
 	// add bonded amount to bonded pool module account
+	bondedPoolAmt := bondAmt.Mul(sdk.NewInt(int64(len(validators))))
 	balances = append(balances, banktypes.Balance{
 		Address: authtypes.NewModuleAddress(stakingtypes.BondedPoolName).String(),
-		Coins:   sdk.Coins{sdk.NewCoin(sdk.DefaultBondDenom, bondAmt)},
+		Coins:   sdk.Coins{sdk.NewCoin(sdk.DefaultBondDenom, bondedPoolAmt)},
 	})
 
 	// update total supply


### PR DESCRIPTION
Fix #27 

- Add a test for `app.setInitialStakingDistribution()` method. 
- Fix `govgenhelpers.SetupWithGenesisValSet()` to support more than one validator
- update README and code comments with discoveries found while writing the tests.