### PR TITLE
feat(chore): align Makefile and goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,7 +16,7 @@ builds:
       - CGO_ENABLED=0
     ldflags:
       # .Env.TM_VERSION is provided in the workflow runner environment -> see .github/workflows/release.yml
-      - -s -w -X main.commit={{.Commit}} -X main.date={{ .CommitDate }} -X github.com/cosmos/cosmos-sdk/version.Name=govgen -X github.com/cosmos/cosmos-sdk/version.AppName=govgend -X github.com/cosmos/cosmos-sdk/version.Version=v{{ .Version }} -X github.com/cosmos/cosmos-sdk/version.Commit={{ .Commit }} -X github.com/cosmos/cosmos-sdk/version.BuildTags=netgo,ledger -X github.com/tendermint/tendermint/version.TMCoreSemVer={{ .Env.TM_VERSION }}
+      - -X github.com/cosmos/cosmos-sdk/version.Name=govgen -X github.com/cosmos/cosmos-sdk/version.AppName=govgend -X github.com/cosmos/cosmos-sdk/version.Version=v{{ .Version }} -X github.com/cosmos/cosmos-sdk/version.Commit={{ .Commit }} -X github.com/cosmos/cosmos-sdk/version.BuildTags=netgo,ledger -X github.com/cometbft/cometbft/version.TMCoreSemVer={{ .Env.TM_VERSION }} -w -s
     goos:
       - darwin
       - linux
@@ -50,7 +50,7 @@ checksum:
   algorithm: sha256
 
 snapshot:
-  name_template: SNAPSHOT-{{ .Commit }}
+  name_template: "{{ .Version }}-{{ .ShortCommit }}"
 
 changelog:
   skip: false

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,15 @@
 #!/usr/bin/make -f
 
-BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
 COMMIT := $(shell git log -1 --format='%H')
 
 # don't override user values
 ifeq (,$(VERSION))
-  VERSION := $(shell git describe --exact-match 2>/dev/null)
+  VERSION := $(shell git describe --tags --exact-match 2>/dev/null)
   # if VERSION is empty, then populate it with branch's name and raw commit hash
   ifeq (,$(VERSION))
-    VERSION := $(BRANCH)-$(COMMIT)
+    PREVIOUS_TAG := $(shell git describe --tags --abbrev=0)
+    SHORT_COMMIT := $(shell git rev-parse --short HEAD)
+    VERSION := $(PREVIOUS_TAG)-$(SHORT_COMMIT)
   endif
 endif
 
@@ -24,6 +25,7 @@ GO_SYSTEM_VERSION = $(shell go version | cut -c 14- | cut -d' ' -f1 | cut -d'.' 
 REQUIRE_GO_VERSION = 1.20
 
 export GO111MODULE = on
+export CGO_ENABLED = 0
 
 # process build tags
 
@@ -68,7 +70,7 @@ ldflags = -X github.com/cosmos/cosmos-sdk/version.Name=govgen \
 		  -X github.com/cosmos/cosmos-sdk/version.AppName=govgend \
 		  -X github.com/cosmos/cosmos-sdk/version.Version=$(VERSION) \
 		  -X github.com/cosmos/cosmos-sdk/version.Commit=$(COMMIT) \
-		  -X "github.com/cosmos/cosmos-sdk/version.BuildTags=$(build_tags_comma_sep)" \
+		  -X github.com/cosmos/cosmos-sdk/version.BuildTags=$(build_tags_comma_sep) \
 			-X github.com/cometbft/cometbft/version.TMCoreSemVer=$(TM_VERSION)
 
 ifeq (cleveldb,$(findstring cleveldb,$(GOVGEN_BUILD_OPTIONS)))


### PR DESCRIPTION
So `make build`, `make install` and `goreleaser build` produce the exact same binary.

The fix consists mainly of tuning the ldflags of the Makefile and of the .goreleaser file:
- arguments must be in the same order
- removed `-X main.commit` and `-X main.date` because this is the default ldflags of goreleaser and they were probably blindly reported in the customized version, but they are actually useless since there's no `commit` nor `date` field in the main package of the application.
- replaced tendermint/tendermint by cometbft/cometbft

A couple of other tiny things had to be updated:
- aligning the version name when there's no tag (snapshot.template_name in goreleaser and VERSION var in Makefile)
- fix Makefile VERSION var when there's a tag
- add CGO_ENABLED=0 in Makefile
- remove double quotes around the BuildTags ldflag because it's useless and goreleaser doesn't use double quotes.

Quick demo:
```sh
$ make build install   # produce build/govgend and $GOBIN/govgend

$ goreleaser build --single-target --clean --snapshot   # produce dist/govgend_linux_amd64_v1/govgend

$  sha256sum $GOBIN/govgend build/govgend dist/govgend_linux_amd64_v1/govgend
77c3249d8b6ae81b4bf9d0d1b683ba7658a63db2fff517c50837e91e73e248da  /home/tom/go/bin/govgend
77c3249d8b6ae81b4bf9d0d1b683ba7658a63db2fff517c50837e91e73e248da  build/govgend
77c3249d8b6ae81b4bf9d0d1b683ba7658a63db2fff517c50837e91e73e248da  dist/govgend_linux_amd64_v1/govgend
```