### PR TITLE
feat(cli): tx bytes-to-sign command

### DIFF
--- a/cmd/govgend/cmd/root.go
+++ b/cmd/govgend/cmd/root.go
@@ -256,14 +256,23 @@ func getBytesToSignCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			cmd.Printf("Bytes to sign:\n%s\n", base64.StdEncoding.EncodeToString(bytesToSign))
 
-			cmd.Printf("%s\n", base64.StdEncoding.EncodeToString(bytesToSign))
+			// Print the input tx with the filled `auth_info.signer_infos` field.
+			json, err := clientCtx.TxConfig.TxJSONEncoder()(txBuilder.GetTx())
+			if err != nil {
+				return err
+			}
+			cmd.Printf("Tx with filled `signer_infos`:\n%s\n", json)
 			return nil
 		},
 	}
 	cmd.Flags().String(flags.FlagChainID, "", "The network chain ID")
-	cmd.MarkFlagRequired(flags.FlagFrom)
 	flags.AddTxFlagsToCmd(cmd)
+	cmd.MarkFlagRequired(flags.FlagFrom)
+	cmd.MarkFlagRequired(flags.FlagChainID)
+	cmd.MarkFlagRequired(flags.FlagSequence)
+	cmd.MarkFlagRequired(flags.FlagAccountNumber)
 	return cmd
 }
 

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/stretchr/testify v1.8.4
 	github.com/tendermint/tendermint v0.34.27
 	github.com/tendermint/tm-db v0.6.7
+	golang.org/x/exp v0.0.0-20230905200255-921286631fa9
 	google.golang.org/genproto/googleapis/api v0.0.0-20230913181813-007df8e322eb
 	google.golang.org/grpc v1.58.2
 	google.golang.org/protobuf v1.31.0
@@ -137,7 +138,6 @@ require (
 	go.uber.org/atomic v1.10.0 // indirect
 	go.uber.org/multierr v1.9.0 // indirect
 	golang.org/x/crypto v0.14.0 // indirect
-	golang.org/x/exp v0.0.0-20230905200255-921286631fa9 // indirect
 	golang.org/x/net v0.17.0 // indirect
 	golang.org/x/sys v0.13.0 // indirect
 	golang.org/x/term v0.13.0 // indirect


### PR DESCRIPTION
In the context of [signing transactions securely](https://github.com/atomone-hub/govgen-proposals/blob/main/submit-tx-securely.md), we believe that a universal small and resilient tool to sign transactions is preferable to the large chain binaries that are frequently updated and therefore require frequent auditing.

The first problem that arose in creating such a tool is the need to create the *bytes to sign* from the tx, which is the piece of data to be signed by the private key and then put it into the `signatures: []` field. Creating the *bytes to sign* is problematic because it requires all the proto registrations (for direct signing mode) or all the amino registrations (for amino-json signing mode). These registrations break the *resilient* and *small* properties of the tool because every time the proto of blockchain X is updated, the tool would have to be released again.

But if the blockchain binaries can provide these *bytes to sign*, then we can simply pass them to this tool, in addition to the generated unsigned tx. There's no need for codec registrations anymore.

This PR shows that this is possible, with a new command `tx bytes-to-sign`. Basically, once the tx is generated with an initial `tx (...) --generate-only` command, the output file can be passed to `tx bytes-to-sign` and it will output the *bytes to sign* and the input tx with the `auth_info.signer_infos`  properly filled.