### PR TITLE
fix(gov): revert duplicate amino path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@
 
 ### STATE BREAKING
 
+## v1.0.4
+
+*Sep 20th, 2024*
+
+### BUG FIXES
+
+* Revert fix duplicate amino path in gov module ([#48](https://github.com/atomone-hub/govgen/pull/48))
+
 ## v1.0.3
 
 *Jul 1st, 2024*

--- a/x/gov/types/codec.go
+++ b/x/gov/types/codec.go
@@ -14,11 +14,11 @@ import (
 // governance module.
 func RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
 	cdc.RegisterInterface((*Content)(nil), nil)
-	cdc.RegisterConcrete(&MsgSubmitProposal{}, "govgen/MsgSubmitProposal", nil)
-	cdc.RegisterConcrete(&MsgDeposit{}, "govgen/MsgDeposit", nil)
-	cdc.RegisterConcrete(&MsgVote{}, "govgen/MsgVote", nil)
-	cdc.RegisterConcrete(&MsgVoteWeighted{}, "govgen/MsgVoteWeighted", nil)
-	cdc.RegisterConcrete(&TextProposal{}, "govgen/TextProposal", nil)
+	cdc.RegisterConcrete(&MsgSubmitProposal{}, "cosmos-sdk/MsgSubmitProposal", nil)
+	cdc.RegisterConcrete(&MsgDeposit{}, "cosmos-sdk/MsgDeposit", nil)
+	cdc.RegisterConcrete(&MsgVote{}, "cosmos-sdk/MsgVote", nil)
+	cdc.RegisterConcrete(&MsgVoteWeighted{}, "cosmos-sdk/MsgVoteWeighted", nil)
+	cdc.RegisterConcrete(&TextProposal{}, "cosmos-sdk/TextProposal", nil)
 }
 
 func RegisterInterfaces(registry types.InterfaceRegistry) {

--- a/x/gov/types/msgs_test.go
+++ b/x/gov/types/msgs_test.go
@@ -64,7 +64,7 @@ func TestMsgDepositGetSignBytes(t *testing.T) {
 	msg := NewMsgDeposit(addr, 0, coinsPos)
 	res := msg.GetSignBytes()
 
-	expected := `{"type":"govgen/MsgDeposit","value":{"amount":[{"amount":"1000","denom":"stake"}],"depositor":"cosmos1v9jxgu33kfsgr5","proposal_id":"0"}}`
+	expected := `{"type":"cosmos-sdk/MsgDeposit","value":{"amount":[{"amount":"1000","denom":"stake"}],"depositor":"cosmos1v9jxgu33kfsgr5","proposal_id":"0"}}`
 	require.Equal(t, expected, string(res))
 }
 
@@ -171,6 +171,6 @@ func TestMsgSubmitProposal_GetSignBytes(t *testing.T) {
 		bz = msg.GetSignBytes()
 	})
 	require.Equal(t,
-		`{"type":"govgen/MsgSubmitProposal","value":{"content":{"type":"govgen/TextProposal","value":{"description":"abcd","title":"test"}},"initial_deposit":[]}}`,
+		`{"type":"cosmos-sdk/MsgSubmitProposal","value":{"content":{"type":"cosmos-sdk/TextProposal","value":{"description":"abcd","title":"test"}},"initial_deposit":[]}}`,
 		string(bz))
 }


### PR DESCRIPTION
Revert PR #44 because it can cause consensus breaking when the network is a mix of versions 1.0.3 and <1.0.3.
Also the legacy amino path are more compliants with existing clients configuration.
